### PR TITLE
Add Docker support and Docker Hub publish step

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,33 @@
+# Dependencies and build output - reinstalled / regenerated inside the image
+node_modules
+frontend/dist
+dist
+
+# VCS and CI metadata
+.git
+.gitignore
+.github
+
+# Editor / OS noise
+.vscode
+.idea
+.DS_Store
+*.swp
+
+# Local environment files - secrets must come from compose / CI, not the image
+.env
+.env.local
+.env.*.local
+
+# Runtime artifacts that should never be baked into the image
+backend/uploads
+backend/data/db.json
+
+# Test artifacts
+coverage
+*.log
+npm-debug.log*
+
+# Docs / assets not needed at runtime
+README.md
+download.png

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,3 +32,35 @@ jobs:
 
       - name: Build application
         run: npm run build
+
+  docker-publish:
+    name: Build and push Docker image
+    needs: test-and-build
+    # Only push images on real commits, never on pull requests from forks.
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push image tagged with commit SHA
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/hotel-web-app:${{ github.sha }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,56 @@
+# syntax=docker/dockerfile:1.7
+
+# ---------- Build stage ----------
+# Installs all dependencies (incl. dev) and builds the Vite frontend.
+FROM node:22-alpine AS builder
+
+WORKDIR /app
+
+# Install dependencies based on the lockfile for reproducible builds
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source needed to build
+COPY tsconfig.json ./
+COPY frontend ./frontend
+COPY backend ./backend
+
+# Produces frontend/dist
+RUN npm run build
+
+
+# ---------- Runtime stage ----------
+# Slim production image. The same image is used in dev (via docker compose),
+# staging, and production - environment variables control behavior.
+FROM node:22-alpine AS runtime
+
+ENV NODE_ENV=production \
+    PORT=3001
+
+WORKDIR /app
+
+# Install production dependencies only
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+# Copy the backend source and built frontend from the builder stage
+COPY --from=builder /app/backend ./backend
+COPY --from=builder /app/frontend/dist ./frontend/dist
+
+# Ensure writable directories for uploads and the legacy JSON db.
+# (Postgres will replace db.json, but the path still needs to exist
+# while the migration is in flight.)
+RUN mkdir -p /app/backend/uploads /app/backend/data \
+ && addgroup -S app \
+ && adduser  -S app -G app \
+ && chown -R app:app /app
+
+USER app
+
+EXPOSE 3001
+
+# Uses Node 22's global fetch - no extra packages required.
+HEALTHCHECK --interval=30s --timeout=5s --start-period=15s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.PORT||3001)+'/api/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
+
+CMD ["node", "backend/api.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,61 @@
+# Local development stack.
+#
+# The `app` service uses the SAME Dockerfile that will be published to
+# Docker Hub and deployed to staging / production - only env vars differ.
+# A local Postgres instance is included so the planned db.json -> Postgres
+# migration can be developed against a real database.
+#
+# Usage:
+#   docker compose up --build           # build image and start app + db
+#   docker compose down                 # stop containers (keeps volumes)
+#   docker compose down -v              # stop and wipe the postgres volume
+
+services:
+  db:
+    image: postgres:16-alpine
+    container_name: hotel-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: hotel
+      POSTGRES_PASSWORD: hotel_dev_password
+      POSTGRES_DB: hotel
+    ports:
+      # Exposed on the host so you can connect with psql / a GUI client
+      - "5432:5432"
+    volumes:
+      - hotel_pgdata:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U hotel -d hotel"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
+
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    image: hotel-web-app:dev
+    container_name: hotel-app
+    restart: unless-stopped
+    environment:
+      NODE_ENV: development
+      PORT: 3001
+      AUTH_SECRET: dev-secret-change-me
+      APP_URL: http://localhost:5173
+      # Ready for the planned Postgres migration. backend/api.js does not
+      # consume this yet, but the database is available at this URL.
+      DATABASE_URL: postgres://hotel:hotel_dev_password@db:5432/hotel
+    ports:
+      - "3001:3001"
+    depends_on:
+      db:
+        condition: service_healthy
+    volumes:
+      # Persist uploads and the legacy JSON db across container restarts
+      - hotel_uploads:/app/backend/uploads
+      - hotel_data:/app/backend/data
+
+volumes:
+  hotel_pgdata:
+  hotel_uploads:
+  hotel_data:


### PR DESCRIPTION
Adds Docker support for the project:

- Dockerfile: multi-stage Node 22 build, runs as non-root, healthchecks /api/health
- docker-compose.yml: local dev with app + Postgres 16, ready for the planned db.json -> Postgres migration
- .dockerignore: keeps node_modules, .env, dist, uploads out of the image
- ci.yml: new docker-publish job runs after tests pass, pushes image to Docker Hub tagged with commit SHA

Tested locally with docker compose, and the CI on this branch is green - image is already on Docker Hub at bryanleongquan/hotel-web-app.

Secrets DOCKERHUB_USERNAME and DOCKERHUB_TOKEN have been added to repo settings.